### PR TITLE
feat(main): 添加测试API和WebSocket端点并支持自定义日志目录

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Response, WebSocket
+from fastapi import APIRouter, Response, WebSocket, WebSocketDisconnect
 from src.utils.logger import get_module_logger
 import signal
 import sys
@@ -66,6 +66,28 @@ async def root_dashboard():
 
 # APIRouterV1 上定义的所有路由都将以 API_PREFIX 为前缀
 
+
+# 添加测试API端点
+@global_server.app.get("/api/test")
+async def test_endpoint():
+    return {"status": "success", "message": "后端运行正常", "port": HTTP_PORT}
+
+# 添加简单的WebSocket测试端点
+@global_server.app.websocket("/ws")
+async def simple_websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            logger.info(f"收到WebSocket消息: {data}")
+            # 处理消息...
+            await websocket.send_text(f"收到消息: {data}")
+    except WebSocketDisconnect:
+        logger.info("WebSocket连接断开")
+    except Exception as e:
+        logger.error(f"WebSocket错误: {e}")
+    finally:
+        await websocket.close()
 
 # 添加 WebSocket 路由
 # 注意：路径中的 {session_id} 将被传递给 handle_websocket_connection

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -46,7 +46,8 @@ _custom_style_handlers: dict[Tuple[str, str], List[int]] = {}  # 记录自定义
 
 # 获取日志存储根地址
 current_file_path = Path(__file__).resolve()
-LOG_ROOT = get_resource_path("logs")
+# 日志根目录 - 支持通过环境变量自定义
+LOG_ROOT = os.environ.get("LOGS_DIR", get_resource_path("logs"))
 
 # LOG_LEVEL = global_config.get("Debug", {}).get("level", "INFO").upper()
 # print(global_config.debug_level)


### PR DESCRIPTION
添加测试API端点以检查后端运行状态

实现简单的WebSocket测试端点

支持通过环境变量自定义日志目录

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加健康检查 API 和 WebSocket 端点，并允许通过环境变量配置日志存储路径

新特性：
- 在 /api/test 添加 HTTP 测试端点，用于健康检查
- 在 /ws 添加简单的 WebSocket 测试端点，用于回显消息

增强功能：
- 允许通过 `LOGS_DIR` 环境变量自定义日志目录

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add health-check API and WebSocket endpoints and allow configuring the log storage path via environment variable

New Features:
- Add HTTP test endpoint at /api/test for health checks
- Add simple WebSocket test endpoint at /ws for echo messages

Enhancements:
- Enable customizing the log directory via the LOGS_DIR environment variable

</details>